### PR TITLE
Add realtime sampling toggle for Skyn to the API

### DIFF
--- a/BACDeviceMangementProtocol.h
+++ b/BACDeviceMangementProtocol.h
@@ -34,6 +34,8 @@
 // Scan for Skyn BacTrack devices
 -(void)scanForSkyn;
 
+-(void)toggleRealTimeForSkyn:(BOOL)toggle;
+
 // Stop scanning for BacTrack and Skyn breathalyzers
 -(void)stopScan;
 

--- a/BacTrackAPI.m
+++ b/BacTrackAPI.m
@@ -219,6 +219,11 @@
     [cmanager scanForPeripheralsWithServices:scanUdids options:0];
 }
 
+-(void)toggleRealTimeForSkyn:(BOOL)toggle
+{
+    [mSkynApi setRealTimeModeEnabled:toggle];
+}
+
 -(void)stopScan
 {
     shouldBeScanning = NO;

--- a/Skyn/BacTrackAPI_Skyn.h
+++ b/Skyn/BacTrackAPI_Skyn.h
@@ -18,5 +18,6 @@
 - (void) fetchRecords;
 - (void) startSync;
 - (void) discardFetchedRecords;
+- (void) setRealTimeModeEnabled:(bool)enabled;
 
 @end


### PR DESCRIPTION
### What

Adding the ability to the SDK to enable to disable realtime sampling.

### Why

So the skyn flutter app can have access to toggle on the real time sampling rate.