### PR TITLE
BAC 548 - Enabling Background Event Notification

### DIFF
--- a/BacTrackAPI.m
+++ b/BacTrackAPI.m
@@ -152,11 +152,9 @@
         connectToNearest = NO;
        
         [self loadProtocolSelectors];
-        connectedPeripherals = [[NSMutableDictionary alloc] initWithCapacity:1];
-        connectedAPIEndpoints = [[NSMutableDictionary alloc] initWithCapacity:1];
-        cmanager = [[CBCentralManager alloc] initWithDelegate:self
-                                                           queue:nil
-                                                         options:[NSDictionary dictionaryWithObject:[NSNumber numberWithInt:0] forKey:CBCentralManagerOptionShowPowerAlertKey]];
+        connectedPeripherals = [[NSMutableDictionary alloc] initWithCapacity: 1];
+        connectedAPIEndpoints = [[NSMutableDictionary alloc] initWithCapacity: 1];
+        cmanager = [[CBCentralManager alloc] initWithDelegate: self queue: nil options: @{ CBCentralManagerOptionRestoreIdentifierKey: @"com.bactrack.centralmanager", CBCentralManagerOptionShowPowerAlertKey: @(NO)}];
         
         NSLog(@"%@: CBCentralManager initialized", self.class.description);
     }
@@ -631,6 +629,9 @@
 /****************************************************************************/
 /*			     CBCentralManagerDelegate protocol methods beneeth here     */
 /****************************************************************************/
+
+- (void)centralManager:(CBCentralManager *)central willRestoreState:(NSDictionary<NSString *,id> *)dict {
+}
 
 - (void) centralManagerDidUpdateState:(CBCentralManager *)central
 {

--- a/BacTrackAPIDelegate.h
+++ b/BacTrackAPIDelegate.h
@@ -219,5 +219,7 @@ typedef NS_ENUM(NSInteger, BACtrackReturnType) {
 
 - (void)BacTrackAuthenticationIsInsufficientError;
 
+- (void)BacTrackSkynSyncRequest;
+
 @end
 

--- a/Pods/Target Support Files/Pods-BACtrack/Pods-BACtrack-Info.plist
+++ b/Pods/Target Support Files/Pods-BACtrack/Pods-BACtrack-Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleDevelopmentRegion</key>
-  <string>en</string>
-  <key>CFBundleExecutable</key>
-  <string>${EXECUTABLE_NAME}</string>
-  <key>CFBundleIdentifier</key>
-  <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
-  <key>CFBundleInfoDictionaryVersion</key>
-  <string>6.0</string>
-  <key>CFBundleName</key>
-  <string>${PRODUCT_NAME}</string>
-  <key>CFBundlePackageType</key>
-  <string>FMWK</string>
-  <key>CFBundleShortVersionString</key>
-  <string>1.0.0</string>
-  <key>CFBundleSignature</key>
-  <string>????</string>
-  <key>CFBundleVersion</key>
-  <string>${CURRENT_PROJECT_VERSION}</string>
-  <key>NSPrincipalClass</key>
-  <string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.1</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${CURRENT_PROJECT_VERSION}</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Skyn/BacTrackAPI_Skyn.m
+++ b/Skyn/BacTrackAPI_Skyn.m
@@ -565,6 +565,7 @@
                 mCharacteristicSerialTx = characteristic;
         }
         [mPeripheral setNotifyValue:YES forCharacteristic:mCharacteristicSerialRx];
+        [mPeripheral setNotifyValue:YES forCharacteristic:mCharacteristicSerialTx];
     }
     else if (service==mServiceVersions) {
         for(CBCharacteristic *characteristic in service.characteristics) {

--- a/Skyn/BacTrackAPI_Skyn.m
+++ b/Skyn/BacTrackAPI_Skyn.m
@@ -69,7 +69,7 @@
     return self;
 }
 
-- (void) configurePeripheral
+- (void)configurePeripheral
 {
     if (![self isConnectedOrConnecting]) {
         return;
@@ -120,7 +120,7 @@
     mChunkSamplePoints = nil;
 }
 
--(void) parseRecords:(Byte *)bytes length:(NSUInteger)length
+-(void)parseRecords:(Byte *)bytes length:(NSUInteger)length
 {
     const Byte TIMESTAMP_AND_SAMPLE_RATE = 0x0;
     const Byte SENSOR_DATA = 0x1;
@@ -364,6 +364,11 @@
         NSString *serialNumber = [[NSString alloc] initWithData:characteristic.value encoding:NSUTF8StringEncoding];
         if ([self.delegate respondsToSelector:@selector(BacTrackSerial:)])
             [self.delegate BacTrackSerial:serialNumber];
+    }
+    else if (characteristic == mCharacteristicSerialTx)
+    {
+        if ([self.delegate respondsToSelector:@selector(BacTrackSkynSyncRequest)])
+            [self.delegate BacTrackSkynSyncRequest];
     }
 }
 


### PR DESCRIPTION
### What

This is a PR that supports adding a setNotify, effectively a listener, that will notify any clients when a advertising service characteristic is found after, this event only occurs during a disconnected state on a bonded connection.

Calls the delegate to notify a parent application that they might want to do something.

### Why

So that we know when we should ask for new data in a background situation.