### PR TITLE
1.0.2 - Background Syncing for Skyn Revision

### DIFF
--- a/BACDeviceMangementProtocol.h
+++ b/BACDeviceMangementProtocol.h
@@ -33,6 +33,7 @@
 -(void)startScan;
 // Scan for Skyn BacTrack devices
 -(void)scanForSkyn;
+-(void)searchForSkyn;
 
 -(void)toggleRealTimeForSkyn:(BOOL)toggle;
 

--- a/BACtrackSDKV2.podspec
+++ b/BACtrackSDKV2.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "BACtrackSDKV2"
-  spec.version      = "1.0.0"
+  spec.version      = "1.0.2"
   spec.summary      = "BACtrack iOS SDK V2"
 
   # This description is used to generate tags and improve search results.

--- a/BacTrackAPI.m
+++ b/BacTrackAPI.m
@@ -800,7 +800,7 @@
     [self getDiscoveredBreathalyzerType:breathalyzer withServices:[advertisementData objectForKey:@"kCBAdvDataServiceUUIDs"]];
 
     // Listen for Skyn Specific Notifications
-    if ([[advertisementData objectForKey:@"kCBAdvDataServiceUUIDs"] containsObject:SKYN_SERIAL_GATT_TX_CHAR_UUID])
+    if ([[advertisementData objectForKey:@"kCBAdvDataServiceUUIDs"] containsObject: [CBUUID UUIDWithString:SKYN_SERIAL_GATT_TX_CHAR_UUID]])
     {
         if ([self.delegate respondsToSelector:@selector(BacTrackSkynSyncRequest)])
             [self.delegate BacTrackSkynSyncRequest];

--- a/BacTrackAPI.m
+++ b/BacTrackAPI.m
@@ -217,6 +217,11 @@
     [cmanager scanForPeripheralsWithServices:scanUdids options:0];
 }
 
+-(void)searchForSkyn
+{
+    [cmanager scanForPeripheralsWithServices:@[[CBUUID UUIDWithString:SKYN_SERIAL_GATT_TX_CHAR_UUID]] options:0];
+}
+
 -(void)toggleRealTimeForSkyn:(BOOL)toggle
 {
     [mSkynApi setRealTimeModeEnabled:toggle];
@@ -631,6 +636,7 @@
 /****************************************************************************/
 
 - (void)centralManager:(CBCentralManager *)central willRestoreState:(NSDictionary<NSString *,id> *)dict {
+    // Not required to be implemented for our use cases. But required by the framework when using background modes.
 }
 
 - (void) centralManagerDidUpdateState:(CBCentralManager *)central
@@ -792,7 +798,14 @@
     breathalyzer.uuid = peripheral.identifier.UUIDString;
     
     [self getDiscoveredBreathalyzerType:breathalyzer withServices:[advertisementData objectForKey:@"kCBAdvDataServiceUUIDs"]];
-    
+
+    // Listen for Skyn Specific Notifications
+    if ([[advertisementData objectForKey:@"kCBAdvDataServiceUUIDs"] containsObject:SKYN_SERIAL_GATT_TX_CHAR_UUID])
+    {
+        if ([self.delegate respondsToSelector:@selector(BacTrackSkynSyncRequest)])
+            [self.delegate BacTrackSkynSyncRequest];
+    }
+
     if(breathalyzer.type != BACtrackDeviceType_Unknown)
     {
         if (!foundBreathalyzers)

--- a/Skyn/BacTrackAPI_Skyn.m
+++ b/Skyn/BacTrackAPI_Skyn.m
@@ -365,11 +365,6 @@
         if ([self.delegate respondsToSelector:@selector(BacTrackSerial:)])
             [self.delegate BacTrackSerial:serialNumber];
     }
-    else if (characteristic == mCharacteristicSerialTx)
-    {
-        if ([self.delegate respondsToSelector:@selector(BacTrackSkynSyncRequest)])
-            [self.delegate BacTrackSkynSyncRequest];
-    }
 }
 
 - (NSDictionary*)nextEventOfType:(int)eventCode fromIndex:(int*)idx
@@ -570,7 +565,6 @@
                 mCharacteristicSerialTx = characteristic;
         }
         [mPeripheral setNotifyValue:YES forCharacteristic:mCharacteristicSerialRx];
-        [mPeripheral setNotifyValue:YES forCharacteristic:mCharacteristicSerialTx];
     }
     else if (service==mServiceVersions) {
         for(CBCharacteristic *characteristic in service.characteristics) {


### PR DESCRIPTION
### What

This changing a few of the methods from the previous PR. New things learned and updated the way we listen and react to events.

### Why

So we can do device-based syncing. (The device tells us when to sync).