### PR TITLE
1.0.3 - Fixing Bluetooth Connection Issue when Unauthorized.

### DIFF
--- a/BACtrackSDKV2.podspec
+++ b/BACtrackSDKV2.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "BACtrackSDKV2"
-  spec.version      = "1.0.2"
+  spec.version      = "1.0.3"
   spec.summary      = "BACtrack iOS SDK V2"
 
   # This description is used to generate tags and improve search results.

--- a/BacTrackAPI.m
+++ b/BacTrackAPI.m
@@ -485,6 +485,12 @@
         else
             [self startScan];
         connectToNearest = YES;
+    } else if (cmanager.state == CBManagerStateUnauthorized) {
+      NSMutableDictionary *errorDetail = [NSMutableDictionary dictionary];
+      [errorDetail setValue:@"The app is not allowed to use bluetooth" forKey:NSLocalizedDescriptionKey];
+      NSError *error = [NSError errorWithDomain:@"Bluetooth Error" code:100 userInfo:errorDetail];
+      if ([self.delegate respondsToSelector:@selector(BacTrackError:)])
+          [self.delegate BacTrackError:error];
     }
     else
     {

--- a/MobileV2/BacTrackAPI_MobileV2.m
+++ b/MobileV2/BacTrackAPI_MobileV2.m
@@ -285,12 +285,7 @@
         val[1] = 0x02;
         
         NSData *data = [NSData dataWithBytes:&val length:2];
-        @try {
-            [bacTrack writeValue:data forCharacteristic:charGenericRx type:CBCharacteristicWriteWithResponse];
-        } @catch (NSException *exception) {
-            //some error
-            [delegate someerrorhappens:message]
-        }
+        [bacTrack writeValue:data forCharacteristic:charGenericRx type:CBCharacteristicWriteWithResponse];
         
     }
     else

--- a/MobileV2/BacTrackAPI_MobileV2.m
+++ b/MobileV2/BacTrackAPI_MobileV2.m
@@ -285,7 +285,13 @@
         val[1] = 0x02;
         
         NSData *data = [NSData dataWithBytes:&val length:2];
-        [bacTrack writeValue:data forCharacteristic:charGenericRx type:CBCharacteristicWriteWithResponse];
+        @try {
+            [bacTrack writeValue:data forCharacteristic:charGenericRx type:CBCharacteristicWriteWithResponse];
+        } @catch (NSException *exception) {
+            //some error
+            [delegate someerrorhappens:message]
+        }
+        
     }
     else
     {


### PR DESCRIPTION
### What

Sending a message that the app is not authorized for bluetooth if we try to connect to Skyn. Rather than infinitely loop into connecting to skyn. (When we can't)

### Why

Because when a client tries to connect to skyn, we get stuck infinitely connecting to Skyn.