### PR TITLE
Syncing with Retronyms

### DIFF
--- a/BACDeviceMangementProtocol.h
+++ b/BACDeviceMangementProtocol.h
@@ -33,9 +33,8 @@
 -(void)startScan;
 // Scan for Skyn BacTrack devices
 -(void)scanForSkyn;
--(void)searchForSkyn;
-
--(void)toggleRealTimeForSkyn:(BOOL)toggle;
+// Start scanning in background mode
+-(void)beginSkynBackgroundMode;
 
 // Stop scanning for BacTrack and Skyn breathalyzers
 -(void)stopScan;
@@ -48,6 +47,7 @@
 // Connected to breathalyzer. Else timesout after given duration in seconds
 -(void)flashBreathalyzerLEDs:(Breathalyzer*)breathalyzer withTimeout:(NSTimeInterval)timeout;
 
+-(void)skynSetRealtimeMode:(BOOL)isEnabled;
 -(void)fetchSkynRecords;
 -(void)skynStartSync;
 -(void)discardFetchedSkynRecords;

--- a/BACtrackSDKV2.podspec
+++ b/BACtrackSDKV2.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "BACtrackSDKV2"
-  spec.version      = "1.0.3"
+  spec.version      = "1.1.0"
   spec.summary      = "BACtrack iOS SDK V2"
 
   # This description is used to generate tags and improve search results.

--- a/BacTrackAPIDelegate.h
+++ b/BacTrackAPIDelegate.h
@@ -217,9 +217,5 @@ typedef NS_ENUM(NSInteger, BACtrackReturnType) {
 
 - (void)BacTrackSkynProcessedRecordCount:(NSUInteger)processedRecordCount;
 
-- (void)BacTrackAuthenticationIsInsufficientError;
-
-- (void)BacTrackSkynSyncRequest;
-
 @end
 

--- a/Globals.h
+++ b/Globals.h
@@ -18,6 +18,7 @@ typedef NS_ENUM(NSInteger, BACtrackDeviceType) {
     BACtrackDeviceType_C6,
     BACtrackDeviceType_C8,
     BACtrackDeviceType_Skyn,
+    BACtrackDeviceType_SkynBackground,  // This reports its type as Skyn once discovered
     BACtrackDeviceType_MobileV2,
     BACtrackDeviceType_Unknown
 };
@@ -70,10 +71,11 @@ typedef enum {
 #define MOBILEV2_GENERIC_GATT_RX_CHAR_UUID @"3CAA1002-0060-4787-9DA2-533C53B399A0"
 
 // Skyn Protocol
-#define SKYN_ADVERTISED_SERVICE_UUID @"e8f90001-0708-430d-93c2-37a17a6191fc"
-#define SKYN_SERIAL_GATT_SERVICE_UUID @"e8f90001-0708-430d-93c2-37a17a6191fc"
-#define SKYN_SERIAL_GATT_TX_CHAR_UUID @"e8f90002-0708-430d-93c2-37a17a6191fc"
-#define SKYN_SERIAL_GATT_RX_CHAR_UUID @"e8f90003-0708-430d-93c2-37a17a6191fc"
+#define SKYN_ADVERTISED_SERVICE_UUID        @"e8f90001-0708-430d-93c2-37a17a6191fc"
+#define SKYN_ADVERTISED_SYNC_SERVICE_UUID   @"e8f90002-0708-430d-93c2-37a17a6191fc"
+#define SKYN_SERIAL_GATT_SERVICE_UUID       @"e8f90001-0708-430d-93c2-37a17a6191fc"
+#define SKYN_SERIAL_GATT_TX_CHAR_UUID       @"e8f90002-0708-430d-93c2-37a17a6191fc"
+#define SKYN_SERIAL_GATT_RX_CHAR_UUID       @"e8f90003-0708-430d-93c2-37a17a6191fc"
 
 
 // Characteristics
@@ -244,6 +246,7 @@ typedef enum {
 #define SKYN_RESULT_KEY_EVENT_CODE              @"event_code"
 #define SKYN_RESULT_KEY_EVENT_PAYLOAD           @"event_payload"
 
+#define SKYN_RESULT_KEY_FIRMWARE                @"firmware"
 
 
 

--- a/Globals.h
+++ b/Globals.h
@@ -18,9 +18,9 @@ typedef NS_ENUM(NSInteger, BACtrackDeviceType) {
     BACtrackDeviceType_C6,
     BACtrackDeviceType_C8,
     BACtrackDeviceType_Skyn,
-    BACtrackDeviceType_SkynBackground,  // This reports its type as Skyn once discovered
     BACtrackDeviceType_MobileV2,
-    BACtrackDeviceType_Unknown
+    BACtrackDeviceType_Unknown,
+    BACtrackDeviceType_SkynBackground,  // This reports its type as Skyn once discovered
 };
 
 typedef enum {

--- a/Skyn/BacTrackAPI_Skyn.h
+++ b/Skyn/BacTrackAPI_Skyn.h
@@ -9,7 +9,11 @@
 #import "BacTrackAPIDelegate.h"
 
 @interface BacTrackAPI_Skyn : NSObject
-
+{
+    NSMutableArray   * mBatchResults;
+    NSMutableDictionary   * mCalibrationPoints;
+    NSMutableArray   * mChunkSamplePoints;
+}
 @property id <BacTrackAPIDelegate> delegate;
 @property BACtrackDeviceType type;
 
@@ -18,6 +22,14 @@
 - (void) fetchRecords;
 - (void) startSync;
 - (void) discardFetchedRecords;
-- (void) setRealTimeModeEnabled:(bool)enabled;
+- (void) setRealtimeModeEnabled:(BOOL)isEnabled;   // Turned off automatically on startSync
+
+#ifdef DEBUG
+// Exposure for unit tests (TODO: move to a private interface file to reduce clutter)
+- (void) fixTimestamps;
+- (void) startNewSkynChunkAtTimestamp:(uint32_t)ts andSampleRate:(uint32_t)sR;
+- (void) saveSkynChunk;
+- (void) handleFinishedRecordBatch;
+#endif
 
 @end

--- a/Skyn/BacTrackAPI_Skyn.m
+++ b/Skyn/BacTrackAPI_Skyn.m
@@ -650,7 +650,6 @@
 
         // Discover characteristics of found services
         for (CBService * service in mPeripheral.services) {
-            
             // Save service one
             if ([service.UUID isEqual:[CBUUID UUIDWithString:SKYN_SERIAL_GATT_SERVICE_UUID]]) {
                 mServiceSerial = service;


### PR DESCRIPTION
### What

- Renaming a few functions that Very previously implemented to follow the Retronym's way. (Background Syncing)
- Support Skyn T15's signed alcohol sensor readings
- Only enable bluetooth-central background mode if the app bundle supports it
- Include Skyn firmware version in batches
- Implement persistent backgrounding for Skyn
- Reset scan UUIDs on stopScan

### Why

- There are some updates and changes and this is a sync into that.

### Notes

- There will need to be some minor changes in the Skyn Flutter app to accommodate these things.