### PR TITLE
BAC 753 - Bug Fixes for SDK Corrections

### DIFF
--- a/BACtrackSDKV2.podspec
+++ b/BACtrackSDKV2.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "BACtrackSDKV2"
-  spec.version      = "1.1.0"
+  spec.version      = "1.1.1"
   spec.summary      = "BACtrack iOS SDK V2"
 
   # This description is used to generate tags and improve search results.

--- a/BacTrackAPIDelegate.h
+++ b/BacTrackAPIDelegate.h
@@ -217,5 +217,7 @@ typedef NS_ENUM(NSInteger, BACtrackReturnType) {
 
 - (void)BacTrackSkynProcessedRecordCount:(NSUInteger)processedRecordCount;
 
+- (void)BacTrackSkynSyncRequest:(Breathalyzer*)breathalyzer;
+
 @end
 


### PR DESCRIPTION
### What
- Ensuring the the breathalyzer is not empty when we connect.
- Re-adding in functionality for presenting a sync opportunity.